### PR TITLE
Updated requirements - update numpy, add xlsxwriter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ importlib-metadata==4.10.1
 itsdangerous==2.0.1
 Jinja2==3.0.3
 MarkupSafe==2.0.1
-numpy==1.21.5
+numpy==1.23.2
 openpyxl==3.0.9
 pandas==1.1.5
 plotly==5.5.0
@@ -23,4 +23,5 @@ six==1.16.0
 tenacity==8.0.1
 typing_extensions==4.0.1
 Werkzeug==2.0.2
+XlsxWriter==3.0.3
 zipp==3.7.0


### PR DESCRIPTION
Heroku build had an error. The immediate error was stated for Gunicorn. Looking at logs, it was also missing xlsxwriter. I had forgotten that there was an import step for it in app.py, but it wasn't specified yet in requirements.txt. So updated requirements.txt to include xlsxwriter.

Also, when starting to work with the dashboard again, I initially had errors, and had to update numpy. So I've updated numpy in the requirements file as well, to be the same version that I had that made the dashboard work locally.